### PR TITLE
bmm: verify connection mainchain on startup

### DIFF
--- a/consensus/bmm/consensus.go
+++ b/consensus/bmm/consensus.go
@@ -32,17 +32,22 @@ type Bmm struct {
 	treasuryAddress    common.Address
 }
 
-func New(dataDir, host string, port uint16, rpcuser, rpcpassword string) Bmm {
+func New(dataDir, host string, port uint16, rpcuser, rpcpassword string) (Bmm, error) {
 	privKey, err := crypto.HexToECDSA(drivechain.TREASURY_PRIVATE_KEY)
 	if err != nil {
 		panic(fmt.Sprintf("can't get treasury private key: %s", err))
 	}
 	address := crypto.PubkeyToAddress(*privKey.Public().(*ecdsa.PublicKey))
-	drivechain.Init(filepath.Join(dataDir, "drivechain"), host, port, rpcuser, rpcpassword)
+	if err := drivechain.Init(
+		filepath.Join(dataDir, "drivechain"), host, port, rpcuser, rpcpassword,
+	); err != nil {
+		return Bmm{}, fmt.Errorf("not able to initialize drivechain: %w", err)
+	}
+
 	return Bmm{
 		treasuryPrivateKey: privKey,
 		treasuryAddress:    address,
-	}
+	}, nil
 }
 
 func (bmm *Bmm) Author(header *types.Header) (common.Address, error) {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -18,6 +18,7 @@
 package ethconfig
 
 import (
+	"fmt"
 	"math/big"
 	"os"
 	"os/user"
@@ -217,7 +218,11 @@ type Config struct {
 func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, config *ethash.Config, notify []string, noverify bool, db ethdb.Database) consensus.Engine {
 	// If proof-of-authority is requested, set it up
 	var engine consensus.Engine
-	var bmm = bmm.New(stack.Config().DataDir, stack.Config().MainHost, uint16(stack.Config().MainPort), stack.Config().MainUser, stack.Config().MainPassword)
+	bmm, err := bmm.New(stack.Config().DataDir, stack.Config().MainHost, uint16(stack.Config().MainPort), stack.Config().MainUser, stack.Config().MainPassword)
+	if err != nil {
+		log.Crit(fmt.Sprintf("Not able to initialize BMM engine: %s", err))
+	}
+
 	engine = &bmm
 	if false {
 		if chainConfig.Clique != nil {


### PR DESCRIPTION
There's two commits here. The first one verifies the connection to the mainchain on startup, instead of failing horribly later on in the case of bad config. 

The second commit I'm a bit unsure of: I had to apply these changes to get this to compile. However, I have zero experience with FFI/cgo. Is this because I'm on macos, and this was originally built for Linux? In that case we might need to introduce platform-specific Go files (which is easy, and I can help with that). 