### PR TITLE
drivechain: use darwin cgo build tags

### DIFF
--- a/drivechain/drivechain.go
+++ b/drivechain/drivechain.go
@@ -135,7 +135,7 @@ func ConnectBlock(deposits []Deposit, withdrawals map[common.Hash]Withdrawal, re
 	for i, deposit := range deposits {
 		cDeposit := C.Deposit{
 			address: C.CString(strings.ToLower(deposit.Address.String())),
-			amount:  C.ulong(deposit.Amount.Uint64()),
+			amount:  newUlong(deposit.Amount.Uint64()),
 		}
 		depositsSlice[i] = cDeposit
 	}
@@ -152,8 +152,8 @@ func ConnectBlock(deposits []Deposit, withdrawals map[common.Hash]Withdrawal, re
 			cWithdrawal := C.Withdrawal{
 				id:      C.CString(id.Hex()),
 				address: w.Address,
-				amount:  C.ulong(w.Amount.Uint64()),
-				fee:     C.ulong(w.Fee.Uint64()),
+				amount:  newUlong(w.Amount.Uint64()),
+				fee:     newUlong(w.Fee.Uint64()),
 			}
 			withdrawalsSlice[i] = cWithdrawal
 			i += 1
@@ -168,7 +168,7 @@ func ConnectBlock(deposits []Deposit, withdrawals map[common.Hash]Withdrawal, re
 	for i, r := range refunds {
 		cRefund := C.Refund{
 			id:     C.CString(r.Id.Hex()),
-			amount: C.ulong(r.Amount.Uint64()),
+			amount: newUlong(r.Amount.Uint64()),
 		}
 		refundsSlice[i] = cRefund
 	}
@@ -185,7 +185,7 @@ func DisconnectBlock(deposits []Deposit, withdrawals []common.Hash, refunds []co
 	for i, deposit := range deposits {
 		cDeposit := C.Deposit{
 			address: C.CString(strings.ToLower(deposit.Address.String())),
-			amount:  C.ulong(deposit.Amount.Uint64()),
+			amount:  newUlong(deposit.Amount.Uint64()),
 		}
 		depositsSlice[i] = cDeposit
 	}
@@ -231,8 +231,8 @@ func FormatDepositAddress(address string) string {
 
 func CreateDeposit(address common.Address, amount uint64, fee uint64) bool {
 	cAddress := C.CString(strings.ToLower(address.Hex()))
-	cAmount := C.ulong(amount)
-	cFee := C.ulong(fee)
+	cAmount := newUlong(amount)
+	cFee := newUlong(fee)
 	result := C.create_deposit(cAddress, cAmount, cFee)
 	C.free(unsafe.Pointer(cAddress))
 	return bool(result)
@@ -318,7 +318,7 @@ func FormatMainchainAddress(dest [MainchainAddressLength]C.uchar) string {
 func attemptBmm(criticalHash string, prevMainBlockHash string, amount uint64) {
 	cCriticalHash := C.CString(criticalHash)
 	cPrevMainBlockHash := C.CString(prevMainBlockHash)
-	C.attempt_bmm(cCriticalHash, cPrevMainBlockHash, C.ulong(amount))
+	C.attempt_bmm(cCriticalHash, cPrevMainBlockHash, newUlong(amount))
 	C.free(unsafe.Pointer(cCriticalHash))
 	C.free(unsafe.Pointer(cPrevMainBlockHash))
 }

--- a/drivechain/drivechain_darwin.go
+++ b/drivechain/drivechain_darwin.go
@@ -1,0 +1,10 @@
+//go:build darwin
+// +build darwin
+
+package drivechain
+
+import "C"
+
+func newUlong(in uint64) C.ulonglong {
+	return C.ulonglong(in)
+}

--- a/drivechain/drivechain_ulong.go
+++ b/drivechain/drivechain_ulong.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+// +build !darwin
+
+package drivechain
+
+import "C"
+
+func newUlong(in uint64) C.ulong {
+	return C.ulong(in)
+}


### PR DESCRIPTION
Followup from #3

Disclaimer: not completely sure what's going on here. It appears like Darwin (macOS) behaves differently from Linux when it comes to how cgo symbols are exported (am I even using the correct nomenclature here?).

I played around with compiling in a native architecture (ARM), emulated x64 archicture in Docker and my native architecture in Docker, and this worked for all setups.